### PR TITLE
Fix Link to Playground

### DIFF
--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -43,7 +43,7 @@ layout: default
             <b class="col-5">Transitland Playground:</b> If the Onestop ID Registry, Transitland Community Datastore, et al. are frozen and underwater, then the Playground is the tip of that iceberg, demonstrating all the pieces of the data architecture working together.
             <ul>
               <li><a href="http://github.com/transitland/playground">Code on GitHub</a></li>
-              <li><a href="http://playground.transit.land">Try the Playground</a></li>
+              <li><a href="https://transit.land/playground/">Try the Playground</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
http://playground.transit.land/ does not work.  Updated link to match the navbar's location.