### PR TITLE
base URLs can now be set for local environments

### DIFF
--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -7,14 +7,17 @@ module Jekyll
   class EnvironmentVariablesGenerator < Generator
  
     def generate(site)
-      site.config['env'] = ENV['TARGET'] || 'dev'
+      site.config['env'] = ENV['TARGET'] || 'local'
       # Add other environment variables to `site.config` here...
       if site.config['env'] == 'prod'
         site.config['url'] = '//transit.land/'
         site.config['playground_url'] = '//transit.land/playground'
-      else
+      elsif site.config['env'] == 'staging'
         site.config['url'] = '//dev.transit.land/'
         site.config['playground_url'] = '//dev.transit.land/playground'
+      elsif site.config['env'] == 'local'
+        site.config['url'] = '//localhost:4000/'
+        site.config['playground_url'] = '//localhost:4001'
       end
     end
  


### PR DESCRIPTION
CircleCI already sets the environment for production or staging. If environment is not specified, Jekyll will now default to `localhost:4000`. Note that you can also run the Playground code under a separate Jekyll server on port 4001, if you want to use both locally.