### PR TITLE
Add anchors to add a feed help page

### DIFF
--- a/documentation/feed-registry/add-a-feed.md
+++ b/documentation/feed-registry/add-a-feed.md
@@ -12,7 +12,8 @@ Here is a video showing the process, which is also described below.
 <iframe src="https://player.vimeo.com/video/155911567" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </p>
 
-<a name="feedurl"></a>
+<a name="feedurl">
+
 ## Find the link to the feed
 
 The first step in contributing is to open the submission form and find the link to the transit feed. Transitland uses the [General Transit Feed Specification](https://developers.google.com/transit/gtfs/), which is a common way of organizing transit schedules, routes, and associated content. A GTFS feed consists of a .zip file that contains a series of specific text files with this information.
@@ -25,6 +26,7 @@ Your link should point to a .zip file on the web that is hosted by a transit ope
 4. Click Next.
 
 <a name="status"></a>
+
 ### Troubleshoot feed status messages
 
 When you add the URL, Transitland checks that address and validates the contents of the file. If your GTFS feed cannot be parsed for some reason, you will receive a message and be unable to continue adding this feed. If you need help, you can send an email to transitland@mapzen.com, or if you are familiar with GitHub, you can post an issue in the [transitland](https://github.com/transitland/transitland) repository.

--- a/documentation/feed-registry/add-a-feed.md
+++ b/documentation/feed-registry/add-a-feed.md
@@ -12,7 +12,7 @@ Here is a video showing the process, which is also described below.
 <iframe src="https://player.vimeo.com/video/155911567" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </p>
 
-<a name="feedurl">
+<p><a name="feedurl"></a></p>
 
 ## Find the link to the feed
 

--- a/documentation/feed-registry/add-a-feed.md
+++ b/documentation/feed-registry/add-a-feed.md
@@ -7,7 +7,7 @@ layout: documentation
 
 This directory is known as the [Transitland Feed Registry](https://transit.land/feed-registry/). Feed submissions are welcomed from everyone; you need not represent a transit organization! To suggest a feed, only need to know the link to it, and any additional information is optional.
 
-Here is a video showing the process, which is also described below.
+Here is a video showing the feed submission process.
 <p>
 <iframe src="https://player.vimeo.com/video/155911567" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </p>
@@ -25,7 +25,7 @@ Your link should point to a .zip file on the web that is hosted by a transit ope
 3. Paste the address into the text box.
 4. Click Next.
 
-<a name="status"></a>
+<p><a name="status"></a></p>
 
 ### Troubleshoot feed status messages
 
@@ -35,7 +35,8 @@ If Transitland has difficulty accessing the address, check the URL to make sure 
 
 In some cases, Transitland can download the .zip, but there is something unusual about its formatting. Although GTFS has a [defined set of standards](https://developers.google.com/transit/gtfs/reference), sometimes tables or text files are missing, for example. Note that GTFS-realtime, which is used to share real-time updates about transit, is not currently supported in Transitland.
 
-<a name="operators"></a>
+<p><a name="operators"></a></p>
+
 ## Choose the transit operators in the feed
 
 Some feeds have one operator, while others contain multiple operators. For example, within a metro area, the feed may aggregate different transit types, such as light rail lines, buses, and ferry services. In other cases, smaller operators may combine their data into a feed serving a larger region.
@@ -47,7 +48,8 @@ You need to include at least one operator from the feed, and then add any supple
 3. Add the location information. If the operator serves multiple cities and is spread across multiple regions, you can enter the operator's headquarters.
 4. Click Next.
 
-<a name="license"></a>
+<p><a name="license"></a></p>
+
 ## Identify the license for the feed
 
 Many feeds provide licenses or have terms that apply to their use or redistribution. This part of the process of adding a feed can be tricky, so include as much information about the license as you can. Depending on your role and relationship to the operator, you may not feel comfortable answering all of the license questions, and this is okay. For example, an agency official is likely to know more about the license terms than community member who submits a feed.
@@ -59,7 +61,8 @@ The options for this part of the submission process are determined by how much i
 3. If you are able to understand the terms of the license, provide details on whether the feed requires attribution, others can create products derived from the feed, and if the feed can only be redistributed in its original state or if modification is allowed.
 4. Click Next.
 
-<a name="submit"></a>
+<p><a name="submit"></a></p>
+
 ## Submit the feed
 
 At this point, you have provided information about the feed, its operators and locations, and licensing, and are almost done with the submission process. If you provide your contact information, you will be notified when your feed has been added to the Feed Registry, or if there are any issues along the way.

--- a/documentation/feed-registry/add-a-feed.md
+++ b/documentation/feed-registry/add-a-feed.md
@@ -12,6 +12,7 @@ Here is a video showing the process, which is also described below.
 <iframe src="https://player.vimeo.com/video/155911567" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </p>
 
+<a name="feedurl">
 ## Find the link to the feed
 
 The first step in contributing is to open the submission form and find the link to the transit feed. Transitland uses the [General Transit Feed Specification](https://developers.google.com/transit/gtfs/), which is a common way of organizing transit schedules, routes, and associated content. A GTFS feed consists of a .zip file that contains a series of specific text files with this information.
@@ -23,6 +24,7 @@ Your link should point to a .zip file on the web that is hosted by a transit ope
 3. Paste the address into the text box.
 4. Click Next.
 
+<a name="status">
 ### Troubleshoot feed status messages
 
 When you add the URL, Transitland checks that address and validates the contents of the file. If your GTFS feed cannot be parsed for some reason, you will receive a message and be unable to continue adding this feed. If you need help, you can send an email to transitland@mapzen.com, or if you are familiar with GitHub, you can post an issue in the [transitland](https://github.com/transitland/transitland) repository.
@@ -31,6 +33,7 @@ If Transitland has difficulty accessing the address, check the URL to make sure 
 
 In some cases, Transitland can download the .zip, but there is something unusual about its formatting. Although GTFS has a [defined set of standards](https://developers.google.com/transit/gtfs/reference), sometimes tables or text files are missing, for example. Note that GTFS-realtime, which is used to share real-time updates about transit, is not currently supported in Transitland.
 
+<a name="operators">
 ## Choose the transit operators in the feed
 
 Some feeds have one operator, while others contain multiple operators. For example, within a metro area, the feed may aggregate different transit types, such as light rail lines, buses, and ferry services. In other cases, smaller operators may combine their data into a feed serving a larger region.
@@ -42,6 +45,7 @@ You need to include at least one operator from the feed, and then add any supple
 3. Add the location information. If the operator serves multiple cities and is spread across multiple regions, you can enter the operator's headquarters.
 4. Click Next.
 
+<a name="license">
 ## Identify the license for the feed
 
 Many feeds provide licenses or have terms that apply to their use or redistribution. This part of the process of adding a feed can be tricky, so include as much information about the license as you can. Depending on your role and relationship to the operator, you may not feel comfortable answering all of the license questions, and this is okay. For example, an agency official is likely to know more about the license terms than community member who submits a feed.
@@ -53,6 +57,7 @@ The options for this part of the submission process are determined by how much i
 3. If you are able to understand the terms of the license, provide details on whether the feed requires attribution, others can create products derived from the feed, and if the feed can only be redistributed in its original state or if modification is allowed.
 4. Click Next.
 
+<a name="submit">
 ## Submit the feed
 
 At this point, you have provided information about the feed, its operators and locations, and licensing, and are almost done with the submission process. If you provide your contact information, you will be notified when your feed has been added to the Feed Registry, or if there are any issues along the way.

--- a/documentation/feed-registry/add-a-feed.md
+++ b/documentation/feed-registry/add-a-feed.md
@@ -12,7 +12,7 @@ Here is a video showing the process, which is also described below.
 <iframe src="https://player.vimeo.com/video/155911567" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </p>
 
-<a name="feedurl">
+<a name="feedurl"></a>
 ## Find the link to the feed
 
 The first step in contributing is to open the submission form and find the link to the transit feed. Transitland uses the [General Transit Feed Specification](https://developers.google.com/transit/gtfs/), which is a common way of organizing transit schedules, routes, and associated content. A GTFS feed consists of a .zip file that contains a series of specific text files with this information.
@@ -24,7 +24,7 @@ Your link should point to a .zip file on the web that is hosted by a transit ope
 3. Paste the address into the text box.
 4. Click Next.
 
-<a name="status">
+<a name="status"></a>
 ### Troubleshoot feed status messages
 
 When you add the URL, Transitland checks that address and validates the contents of the file. If your GTFS feed cannot be parsed for some reason, you will receive a message and be unable to continue adding this feed. If you need help, you can send an email to transitland@mapzen.com, or if you are familiar with GitHub, you can post an issue in the [transitland](https://github.com/transitland/transitland) repository.
@@ -33,7 +33,7 @@ If Transitland has difficulty accessing the address, check the URL to make sure 
 
 In some cases, Transitland can download the .zip, but there is something unusual about its formatting. Although GTFS has a [defined set of standards](https://developers.google.com/transit/gtfs/reference), sometimes tables or text files are missing, for example. Note that GTFS-realtime, which is used to share real-time updates about transit, is not currently supported in Transitland.
 
-<a name="operators">
+<a name="operators"></a>
 ## Choose the transit operators in the feed
 
 Some feeds have one operator, while others contain multiple operators. For example, within a metro area, the feed may aggregate different transit types, such as light rail lines, buses, and ferry services. In other cases, smaller operators may combine their data into a feed serving a larger region.
@@ -45,7 +45,7 @@ You need to include at least one operator from the feed, and then add any supple
 3. Add the location information. If the operator serves multiple cities and is spread across multiple regions, you can enter the operator's headquarters.
 4. Click Next.
 
-<a name="license">
+<a name="license"></a>
 ## Identify the license for the feed
 
 Many feeds provide licenses or have terms that apply to their use or redistribution. This part of the process of adding a feed can be tricky, so include as much information about the license as you can. Depending on your role and relationship to the operator, you may not feel comfortable answering all of the license questions, and this is okay. For example, an agency official is likely to know more about the license terms than community member who submits a feed.
@@ -57,7 +57,7 @@ The options for this part of the submission process are determined by how much i
 3. If you are able to understand the terms of the license, provide details on whether the feed requires attribution, others can create products derived from the feed, and if the feed can only be redistributed in its original state or if modification is allowed.
 4. Click Next.
 
-<a name="submit">
+<a name="submit"></a>
 ## Submit the feed
 
 At this point, you have provided information about the feed, its operators and locations, and licensing, and are almost done with the submission process. If you provide your contact information, you will be notified when your feed has been added to the Feed Registry, or if there are any issues along the way.


### PR DESCRIPTION
This adds anchor tags in HTML so we have stable anchor links on the add a feed documentation page.

I enclosed the a tags in p tags, as jekyll was generating them automatically...so I added them myself to control their insertion (else, they were getting added around the headings, even with the a tags being closed).