### PR TITLE
Add closing parentheses; fix broken link.

### DIFF
--- a/documentation/datastore/index.md
+++ b/documentation/datastore/index.md
@@ -3,7 +3,7 @@ title: Datastore
 layout: documentation
 ---
 
-The Transitland Datastore brings together data from authoritative sources (listed in the [Feed Registry](documentation/feed-registry/) with contributions, edits, and fixes from transit enthusiasts and developers. It's a hosted service that provides a simple web API for query and editing.
+The Transitland Datastore brings together data from authoritative sources (listed in the [Feed Registry](/documentation/feed-registry/)) with contributions, edits, and fixes from transit enthusiasts and developers. It's a hosted service that provides a simple web API for query and editing.
 
 ## News about the Datastore
 


### PR DESCRIPTION
Page in question – https://transit.land/documentation/datastore/.