### PR TITLE
Update steps to reflect edit button on feed details

### DIFF
--- a/documentation/feed-registry/edit-a-feed.md
+++ b/documentation/feed-registry/edit-a-feed.md
@@ -8,10 +8,7 @@ After a feed is part of the Feed Registry, you can modify the feed's details, in
 To learn more about the items in the feed details, see [Add a feed](add-a-feed.html).
 
 1. In the [Feed Registry](https://transit.land/feed-registry/), click the link in the Operator Name column for the feed you want to update.
-2. In the Feed Details section, copy the URL for the feed's data location.
-2. Navigate to [https://transit.land/feed-registry/feeds/new](https://transit.land/feed-registry/feeds/new).
-3. Paste the feed's URL into the text box.
-4. Click Next.
-5. If a matching operator is found, you see a notification that you are in a mode where you can edit a feed. If no existing operators are found, you are adding the feed. 
-6. Modify only the details you want to change about the feed. 
-7. Submit the feed.
+2. Scroll the page and click Edit feed and operator details.
+3. Verify that the feed's URL is shown in the box and click Next.
+4. Modify only the details you want to change about the feed. 
+5. Submit the feed.


### PR DESCRIPTION
We added a edit feed button on the feed details. This greatly simplified the steps -- yay!

Fixes #194 