### PR TITLE
Add include_geometry to routes endpoint

### DIFF
--- a/documentation/datastore/api-endpoints.md
+++ b/documentation/datastore/api-endpoints.md
@@ -51,7 +51,7 @@ Method | Example URL | Parameters
 `GET` |  `/api/v1/routes?tag_key=route_color&tag_value=FEF0B5` | find all routes that have a tag of `tag_key` and a value of `tag_value`
 `GET` |  `/api/v1/routes?traverses=r-9q9-pittsburg~baypoint~sfia~millbrae-49ae87-5ae164` | find all routes having specified route stop patterns
 `GET` |  `/api/v1/routes?import_level=4` | find all routes with a given import level
-`GET` |  `/api/v1/routes?exclude_geometry=false` | determine whether to return the route geometry. The default is `false`, which means route geometry is included in the response. 
+`GET` |  `/api/v1/routes?include_geometry=false` | determine whether to return the route geometry. The default is `true`, which means route geometry is included in the response. 
 `GET` |  `/api/v1/route_stop_patterns` | none required
 `GET` |  `/api/v1/route_stop_patterns?traversed_by=r-9q8y-richmond~dalycity~millbrae` | find all Route Stop Patterns belonging to route
 `GET` |  `/api/v1/route_stop_patterns?bbox=-122.4183,37.7758,-122.4120,37.7858` | `bbox` is a search bounding box with southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas)

--- a/documentation/datastore/api-endpoints.md
+++ b/documentation/datastore/api-endpoints.md
@@ -51,7 +51,7 @@ Method | Example URL | Parameters
 `GET` |  `/api/v1/routes?tag_key=route_color&tag_value=FEF0B5` | find all routes that have a tag of `tag_key` and a value of `tag_value`
 `GET` |  `/api/v1/routes?traverses=r-9q9-pittsburg~baypoint~sfia~millbrae-49ae87-5ae164` | find all routes having specified route stop patterns
 `GET` |  `/api/v1/routes?import_level=4` | find all routes with a given import level
-`GET` |  `/api/v1/routes?include_geometry=false` | determine whether to return the route geometry. The default is `true`, which means route geometry is included in the response. 
+`GET` |  `/api/v1/routes?include_geometry=true` | determine whether to return the route geometry. The default is `true`, which means route geometry is part of the response. 
 `GET` |  `/api/v1/route_stop_patterns` | none required
 `GET` |  `/api/v1/route_stop_patterns?traversed_by=r-9q8y-richmond~dalycity~millbrae` | find all Route Stop Patterns belonging to route
 `GET` |  `/api/v1/route_stop_patterns?bbox=-122.4183,37.7758,-122.4120,37.7858` | `bbox` is a search bounding box with southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas)

--- a/documentation/datastore/api-endpoints.md
+++ b/documentation/datastore/api-endpoints.md
@@ -51,6 +51,7 @@ Method | Example URL | Parameters
 `GET` |  `/api/v1/routes?tag_key=route_color&tag_value=FEF0B5` | find all routes that have a tag of `tag_key` and a value of `tag_value`
 `GET` |  `/api/v1/routes?traverses=r-9q9-pittsburg~baypoint~sfia~millbrae-49ae87-5ae164` | find all routes having specified route stop patterns
 `GET` |  `/api/v1/routes?import_level=4` | find all routes with a given import level
+`GET` |  `/api/v1/routes?exclude_geometry=false` | determine whether to return the route geometry. The default is `false`, which means route geometry is included in the response. 
 `GET` |  `/api/v1/route_stop_patterns` | none required
 `GET` |  `/api/v1/route_stop_patterns?traversed_by=r-9q8y-richmond~dalycity~millbrae` | find all Route Stop Patterns belonging to route
 `GET` |  `/api/v1/route_stop_patterns?bbox=-122.4183,37.7758,-122.4120,37.7858` | `bbox` is a search bounding box with southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas)


### PR DESCRIPTION
This adds the option to include or exclude the geometry.

See also https://github.com/transitland/transitland-datastore/issues/866

(putting this here, but hold off on merging until discussion on whether it's include_geometry or exclude_geometry)